### PR TITLE
Handle switchBinary.scene_switch_binary type 

### DIFF
--- a/index.js
+++ b/index.js
@@ -524,6 +524,7 @@ ZWayServerAccessory.prototype = {
                 }
                 break;
             case "switchBinary.switch":
+            case "switchBinary.scene_switch_binary":
               services.push(new Service.Switch(vdev.metrics.title, vdev.id));
               break;
             case "switchRGBW":

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "homebridge-zway-kevindayton",
-  "version": "0.6.0-alpha1",
+  "version": "0.6.0-alpha2",
   "description": "homebridge-plugin for ZWay Server and RaZBerry",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
My pi ZWay / homebridge crashed its SD card, so I had to rebuild from scratch. Rather than patching SphtKr version again, I was glad to see this fork. Build went smoothly, except my Lutron switches showed up as Unsupported in HomeKit.  Doing the same investigation, I found that ZWay is now reporting them as device type `switchBinary.scene_switch_binary`, so I've added that in.  

Couple questions while I'm at it:

I see you went around the TagValue checking for Lightbulb/Outlet/windowCovering. While those devices may not be reporting the device type of `switchBinary.switch` or `switchBinary.scene_switch_binary`, is there a reason to not allow that tagging in the config file, just in case they do?

I'm getting an error of 
```
Plugin 'homebridge-zway-kevindayton' tried to register with an incorrect plugin identifier: 'homebridge-zway'.  Please report this to the developer!
```
, so I'm doing exactly that. Is it necessary to move away from the `homebridge-zway` name? If so, couldn't it be just `homebridge-zway2`? Regardless, it apparently needs to be consistent.

While you're looking at all this, should the PRs awaiting in SphtKr be merged in here?

Thanks for updating this!